### PR TITLE
Carregamento dos dados dos cards da camada de Praças e Parques

### DIFF
--- a/controllers/cards/square/square_inequality_controller.go
+++ b/controllers/cards/square/square_inequality_controller.go
@@ -1,0 +1,47 @@
+package controllers_cards_square
+
+import (
+	"net/http"
+	services_cards_square "urbverde-api/services/cards/square"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SquareInequalityController struct {
+	SquareInequalityService services_cards_square.SquareInequalityService
+}
+
+func NewSquareInequalityController(service services_cards_square.SquareInequalityService) *SquareInequalityController {
+	return &SquareInequalityController{
+		SquareInequalityService: service,
+	}
+}
+
+func (ac *SquareInequalityController) LoadInequalityData(c *gin.Context) {
+	city := c.Query("city")
+	year := c.Query("year")
+
+	if year != "" {
+		data, err := ac.SquareInequalityService.LoadInequalityData(city, year)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar dados de cobertura square",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	} else {
+		data, err := ac.SquareInequalityService.LoadYears(city)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar anos disponíveis de cobertura square",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	}
+}

--- a/controllers/cards/square/square_info_controller.go
+++ b/controllers/cards/square/square_info_controller.go
@@ -1,0 +1,33 @@
+package controllers_cards_square
+
+import (
+	"net/http"
+	services_cards_square "urbverde-api/services/cards/square"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SquareInfoController struct {
+	SquareInfoService services_cards_square.SquareInfoService
+}
+
+func NewSquareInfoController(service services_cards_square.SquareInfoService) *SquareInfoController {
+	return &SquareInfoController{
+		SquareInfoService: service,
+	}
+}
+
+func (ac *SquareInfoController) LoadInfoData(c *gin.Context) {
+	city := c.Query("city")
+
+	data, err := ac.SquareInfoService.LoadInfoData(city)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": "Erro ao buscar dados de temperatura",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, data)
+}

--- a/controllers/cards/square/square_parks_controller.go
+++ b/controllers/cards/square/square_parks_controller.go
@@ -1,0 +1,47 @@
+package controllers_cards_square
+
+import (
+	"net/http"
+	services_cards_square "urbverde-api/services/cards/square"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SquareParksController struct {
+	SquareParksService services_cards_square.SquareParksService
+}
+
+func NewSquareParksController(service services_cards_square.SquareParksService) *SquareParksController {
+	return &SquareParksController{
+		SquareParksService: service,
+	}
+}
+
+func (ac *SquareParksController) LoadParksData(c *gin.Context) {
+	city := c.Query("city")
+	year := c.Query("year")
+
+	if year != "" {
+		data, err := ac.SquareParksService.LoadParksData(city, year)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar dados de cobertura square",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	} else {
+		data, err := ac.SquareParksService.LoadYears(city)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar anos disponíveis de cobertura square",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	}
+}

--- a/controllers/cards/square/square_ranking_controller.go
+++ b/controllers/cards/square/square_ranking_controller.go
@@ -1,0 +1,47 @@
+package controllers_cards_square
+
+import (
+	"net/http"
+	services_cards_square "urbverde-api/services/cards/square"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SquareRankingController struct {
+	SquareRankingService services_cards_square.SquareRankingService
+}
+
+func NewSquareRankingController(service services_cards_square.SquareRankingService) *SquareRankingController {
+	return &SquareRankingController{
+		SquareRankingService: service,
+	}
+}
+
+func (ac *SquareRankingController) LoadRankingData(c *gin.Context) {
+	city := c.Query("city")
+	year := c.Query("year")
+
+	if year != "" {
+		data, err := ac.SquareRankingService.LoadRankingData(city, year)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar dados de temperatura",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	} else {
+		data, err := ac.SquareRankingService.LoadYears(city)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Erro ao buscar anos disponíveis de temperatura",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
+	}
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -64,6 +64,176 @@ const docTemplate = `{
                 }
             }
         },
+        "/cards/square/inequality": {
+            "get": {
+                "description": "Retorna dados de desigualdade para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados sobre desigualdade",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/info": {
+            "get": {
+                "description": "Retorna dados adicionais para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados adicionais para a camada de praças e parques",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/parks": {
+            "get": {
+                "description": "Retorna dados de parques e praças para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados dos parques e praças",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/ranking": {
+            "get": {
+                "description": "Retorna dados para a construção do ranking de praças e parques",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados de ranking",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ano dos dados",
+                        "name": "year",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.RankingData"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/cards/vegetal/cover": {
             "get": {
                 "description": "Retorna dados relacionados à cobertura vegetal para o município fornecido",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -58,6 +58,176 @@
                 }
             }
         },
+        "/cards/square/inequality": {
+            "get": {
+                "description": "Retorna dados de desigualdade para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados sobre desigualdade",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/info": {
+            "get": {
+                "description": "Retorna dados adicionais para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados adicionais para a camada de praças e parques",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/parks": {
+            "get": {
+                "description": "Retorna dados de parques e praças para a camada",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados dos parques e praças",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.CardsDataItem"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cards/square/ranking": {
+            "get": {
+                "description": "Retorna dados para a construção do ranking de praças e parques",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cards/square"
+                ],
+                "summary": "Retorna dados de ranking",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Código de município",
+                        "name": "city",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ano dos dados",
+                        "name": "year",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cards.RankingData"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/cards.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/cards/vegetal/cover": {
             "get": {
                 "description": "Retorna dados relacionados à cobertura vegetal para o município fornecido",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -137,6 +137,118 @@ paths:
       summary: Retorna sugestões de endereço
       tags:
       - address
+  /cards/square/inequality:
+    get:
+      consumes:
+      - application/json
+      description: Retorna dados de desigualdade para a camada
+      parameters:
+      - description: Código de município
+        in: query
+        name: city
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/cards.CardsDataItem'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cards.ErrorResponse'
+      summary: Retorna dados sobre desigualdade
+      tags:
+      - cards/square
+  /cards/square/info:
+    get:
+      consumes:
+      - application/json
+      description: Retorna dados adicionais para a camada
+      parameters:
+      - description: Código de município
+        in: query
+        name: city
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/cards.CardsDataItem'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cards.ErrorResponse'
+      summary: Retorna dados adicionais para a camada de praças e parques
+      tags:
+      - cards/square
+  /cards/square/parks:
+    get:
+      consumes:
+      - application/json
+      description: Retorna dados de parques e praças para a camada
+      parameters:
+      - description: Código de município
+        in: query
+        name: city
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/cards.CardsDataItem'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cards.ErrorResponse'
+      summary: Retorna dados dos parques e praças
+      tags:
+      - cards/square
+  /cards/square/ranking:
+    get:
+      consumes:
+      - application/json
+      description: Retorna dados para a construção do ranking de praças e parques
+      parameters:
+      - description: Código de município
+        in: query
+        name: city
+        required: true
+        type: string
+      - description: Ano dos dados
+        in: query
+        name: year
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/cards.RankingData'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/cards.ErrorResponse'
+      summary: Retorna dados de ranking
+      tags:
+      - cards/square
   /cards/vegetal/cover:
     get:
       consumes:

--- a/repositories/cards/square/square_inequality_repository.go
+++ b/repositories/cards/square/square_inequality_repository.go
@@ -22,7 +22,6 @@ type SquareInequalityProperties struct {
 	H9a  float64 `json:"h9a"`  // Idosos
 }
 
-// Response JSON structure
 type SquareInequalityDataItem struct {
 	Title    string  `json:"title"`
 	Subtitle *string `json:"subtitle,omitempty"`

--- a/repositories/cards/square/square_inequality_repository.go
+++ b/repositories/cards/square/square_inequality_repository.go
@@ -1,0 +1,127 @@
+package repositories_cards_square
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	cards_shared "urbverde-api/repositories/cards"
+
+	"github.com/joho/godotenv"
+)
+
+type SquareInequalityRepository interface {
+	cards_shared.RepositoryBase
+	LoadInequalityData(city string, year string) ([]SquareInequalityDataItem, error)
+}
+
+type SquareInequalityProperties struct {
+	Ano  int     `json:"ano"`
+	H12a float64 `json:"h12a"` // Negros e indígenas
+	H11a float64 `json:"h11a"` // Mulheres
+	H10a float64 `json:"h10a"` // Crianças
+	H9a  float64 `json:"h9a"`  // Idosos
+}
+
+// Response JSON structure
+type SquareInequalityDataItem struct {
+	Title    string  `json:"title"`
+	Subtitle *string `json:"subtitle,omitempty"`
+	Value    string  `json:"value"`
+}
+
+type externalSquareInequalityRepository struct {
+	geoserverURL string
+}
+
+func NewExternalSquareInequalityRepository() SquareInequalityRepository {
+	_ = godotenv.Load()
+
+	geoserverURL := os.Getenv("GEOSERVER_URL")
+	if geoserverURL == "" {
+		panic("A variável de ambiente GEOSERVER_URL não está definida")
+	}
+
+	geoserverURL = fmt.Sprintf("%sows?service=%s&version=%s&request=%s&typeName=%s&%s",
+		geoserverURL,
+		cards_shared.WfsService,
+		cards_shared.WfsVersion,
+		cards_shared.WfsRequest,
+		cards_shared.TypeName+"dados_pracas_por_municipio",
+		cards_shared.CqlFilterPrefix,
+	)
+
+	return &externalSquareInequalityRepository{
+		geoserverURL: geoserverURL,
+	}
+}
+
+func (r *externalSquareInequalityRepository) LoadYears(city string) ([]int, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	processProperties := func(props map[string]interface{}) (int, error) {
+		year, ok := props["ano"].(float64)
+		if !ok {
+			return 0, fmt.Errorf("year not found or invalid type")
+		}
+		return int(year), nil
+	}
+
+	return cards_shared.LoadYears(url, processProperties)
+}
+
+func (r *externalSquareInequalityRepository) LoadInequalityData(city string, year string) ([]SquareInequalityDataItem, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	data, err := cards_shared.FetchFromURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	convYear, err := strconv.Atoi(year)
+	if err != nil {
+		return nil, fmt.Errorf("ano inválido: %w", err)
+	}
+
+	var filtered cards_shared.Feature
+	found := false
+	for _, feature := range data.Features {
+		props, ok := feature.Properties.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("tipo inesperado de propriedades")
+		}
+
+		var inequalityProps SquareInequalityProperties
+		if err := cards_shared.MapToStruct(props, &inequalityProps); err != nil {
+			return nil, err
+		}
+
+		if inequalityProps.Ano == convYear {
+			filtered = feature
+			filtered.Properties = inequalityProps
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("ano %d não encontrado nos dados", convYear)
+	}
+
+	inequalityProps := filtered.Properties.(SquareInequalityProperties)
+
+	black_indigenous_value := strconv.FormatFloat(inequalityProps.H12a, 'f', 2, 64)
+	women_value := strconv.FormatFloat(inequalityProps.H11a, 'f', 2, 64)
+	children_value := strconv.FormatFloat(inequalityProps.H10a, 'f', 2, 64)
+	elderly_value := strconv.FormatFloat(inequalityProps.H9a, 'f', 2, 64)
+
+	var general_subtitle string = "Porcentagem vivendo fora da vizinhança das praças"
+
+	result := []SquareInequalityDataItem{
+		{"Negros e indígenas", &general_subtitle, black_indigenous_value + "%"},
+		{"Mulheres", &general_subtitle, women_value + "%"},
+		{"Crianças", &general_subtitle, children_value + "%"},
+		{"Idosos", &general_subtitle, elderly_value + "%"},
+	}
+
+	return result, nil
+}

--- a/repositories/cards/square/square_info_repository.go
+++ b/repositories/cards/square/square_info_repository.go
@@ -134,7 +134,7 @@ func (r *externalSquareInfoRepository) LoadInfoData(city string) ([]InfoDataItem
 
 	result := []InfoDataItem{
 		{"Temperatura média da superfície", strconv.Itoa(int(latestC2)) + "°C"},
-		{"Média da cobertura vegetal", strconv.Itoa(int(latestB1h1)) + "%"},
+		{"Média da cobertura vegetal", strconv.FormatFloat(latestB1h1, 'f', 2, 64) + "%"},
 		{"Desigualdade ambiental e social", strconv.Itoa(int(latestB3))},
 	}
 

--- a/repositories/cards/square/square_info_repository.go
+++ b/repositories/cards/square/square_info_repository.go
@@ -1,0 +1,142 @@
+package repositories_cards_square
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	cards_shared "urbverde-api/repositories/cards"
+
+	"github.com/joho/godotenv"
+)
+
+type SquareInfoRepository interface {
+	LoadInfoData(city string) ([]InfoDataItem, error)
+}
+
+type InfoProperties struct {
+	Ano  int     `json:"ano"`
+	C2   float64 `json:"c2"`   // Temperatura média da superfície (temperature)
+	B1h1 float64 `json:"b1h1"` // Média da cobertura vegetal (vegetal)
+	B3   float64 `json:"b3"`   // Desigualdade ambiental e social (vegetal))
+}
+
+type InfoDataItem struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+type externalSquareInfoRepository struct {
+	temperatureURL string
+	vegetalURL     string
+}
+
+func NewExternalSquareInfoRepository() SquareInfoRepository {
+	_ = godotenv.Load()
+
+	geoserverURL := os.Getenv("GEOSERVER_URL")
+	if geoserverURL == "" {
+		panic("A variável de ambiente GEOSERVER_URL não está definida")
+	}
+
+	temperatureURL := fmt.Sprintf("%sows?service=%s&version=%s&request=%s&typeName=%s&%s",
+		geoserverURL,
+		cards_shared.WfsService,
+		cards_shared.WfsVersion,
+		cards_shared.WfsRequest,
+		cards_shared.TypeName+"dados_temperatura_por_municipio",
+		cards_shared.CqlFilterPrefix,
+	)
+
+	vegetalURL := fmt.Sprintf("%sows?service=%s&version=%s&request=%s&typeName=%s&%s",
+		geoserverURL,
+		cards_shared.WfsService,
+		cards_shared.WfsVersion,
+		cards_shared.WfsRequest,
+		cards_shared.TypeName+"vegetacao_highlights_data",
+		cards_shared.CqlFilterPrefix,
+	)
+
+	return &externalSquareInfoRepository{
+		temperatureURL: temperatureURL,
+		vegetalURL:     vegetalURL,
+	}
+}
+
+func (r *externalSquareInfoRepository) loadGeneralData(city string) (*cards_shared.FeatureCollection, error) {
+	vegetalUrl := r.vegetalURL + city + "&outputFormat=application/json"
+	vegetalData, err := cards_shared.FetchFromURL(vegetalUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	temperatureUrl := r.temperatureURL + city + "&outputFormat=application/json"
+	temperatureData, err := cards_shared.FetchFromURL(temperatureUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	Tdata := append(vegetalData.Features, temperatureData.Features...)
+	data := &cards_shared.FeatureCollection{
+		Features: Tdata,
+	}
+
+	return data, nil
+}
+
+func sortGeneralData(data *cards_shared.FeatureCollection) *cards_shared.FeatureCollection {
+	sort.Slice(data.Features, func(i, j int) bool {
+		propsI := data.Features[i].Properties.(map[string]interface{})
+		propsJ := data.Features[j].Properties.(map[string]interface{})
+
+		anoI, okI := propsI["ano"].(float64)
+		anoJ, okJ := propsJ["ano"].(float64)
+		if !okI || !okJ {
+			panic("campo 'ano' não é do tipo float64")
+		}
+
+		return int(anoI) > int(anoJ)
+	})
+
+	return data
+}
+
+func (r *externalSquareInfoRepository) LoadInfoData(city string) ([]InfoDataItem, error) {
+	data, err := r.loadGeneralData(city)
+	if err != nil {
+		return nil, fmt.Errorf("erro ao carregar dados: %w", err)
+	}
+
+	data = sortGeneralData(data)
+
+	findLatestNonZero := func(features []cards_shared.Feature, key string) (float64, bool) {
+		for _, feature := range features {
+			props, ok := feature.Properties.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			value, ok := props[key].(float64)
+			if ok && value != 0 {
+				return value, true
+			}
+		}
+		return 0, false
+	}
+
+	latestC2, foundC2 := findLatestNonZero(data.Features, "c2")
+	latestB1h1, foundB1h1 := findLatestNonZero(data.Features, "b1h1")
+	latestB3, foundB3 := findLatestNonZero(data.Features, "b3")
+
+	if !foundC2 && !foundB1h1 && !foundB3 {
+		return nil, fmt.Errorf("nenhum dado válido encontrado")
+	}
+
+	result := []InfoDataItem{
+		{"Temperatura média da superfície", strconv.Itoa(int(latestC2)) + "°C"},
+		{"Média da cobertura vegetal", strconv.Itoa(int(latestB1h1)) + "%"},
+		{"Desigualdade ambiental e social", strconv.Itoa(int(latestB3))},
+	}
+
+	return result, nil
+}

--- a/repositories/cards/square/square_parks_repository.go
+++ b/repositories/cards/square/square_parks_repository.go
@@ -1,0 +1,130 @@
+package repositories_cards_square
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	cards_shared "urbverde-api/repositories/cards"
+
+	"github.com/joho/godotenv"
+)
+
+type SquareParksRepository interface {
+	cards_shared.RepositoryBase
+	LoadParksData(city string, year string) ([]ParksDataItem, error)
+}
+
+type ParksProperties struct {
+	Ano int     `json:"ano"`
+	A1  float64 `json:"a1"` // % moradores proximos a praças
+	A4  float64 `json:"a4"` // Distancia média até as praças
+	H6  float64 `json:"h6"` // Desigualdade de renda
+	H7  float64 `json:"h7"` // Racismo ambiental
+}
+
+// Response JSON structure
+type ParksDataItem struct {
+	Title    string  `json:"title"`
+	Subtitle *string `json:"subtitle,omitempty"`
+	Value    string  `json:"value"`
+}
+
+type externalSquareParksRepository struct {
+	geoserverURL string
+}
+
+func NewExternalSquareParksRepository() SquareParksRepository {
+	_ = godotenv.Load()
+
+	geoserverURL := os.Getenv("GEOSERVER_URL")
+	if geoserverURL == "" {
+		panic("A variável de ambiente GEOSERVER_URL não está definida")
+	}
+
+	geoserverURL = fmt.Sprintf("%sows?service=%s&version=%s&request=%s&typeName=%s&%s",
+		geoserverURL,
+		cards_shared.WfsService,
+		cards_shared.WfsVersion,
+		cards_shared.WfsRequest,
+		cards_shared.TypeName+"dados_pracas_por_municipio",
+		cards_shared.CqlFilterPrefix,
+	)
+
+	return &externalSquareParksRepository{
+		geoserverURL: geoserverURL,
+	}
+}
+
+func (r *externalSquareParksRepository) LoadYears(city string) ([]int, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	processProperties := func(props map[string]interface{}) (int, error) {
+		year, ok := props["ano"].(float64)
+		if !ok {
+			return 0, fmt.Errorf("year not found or invalid type")
+		}
+		return int(year), nil
+	}
+
+	return cards_shared.LoadYears(url, processProperties)
+}
+
+func (r *externalSquareParksRepository) LoadParksData(city string, year string) ([]ParksDataItem, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	data, err := cards_shared.FetchFromURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	convYear, err := strconv.Atoi(year)
+	if err != nil {
+		return nil, fmt.Errorf("ano inválido: %w", err)
+	}
+
+	var filtered cards_shared.Feature
+	found := false
+	for _, feature := range data.Features {
+		props, ok := feature.Properties.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("tipo inesperado de propriedades")
+		}
+
+		var parksProps ParksProperties
+		if err := cards_shared.MapToStruct(props, &parksProps); err != nil {
+			return nil, err
+		}
+
+		if parksProps.Ano == convYear {
+			filtered = feature
+			filtered.Properties = parksProps
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("ano %d não encontrado nos dados", convYear)
+	}
+
+	parksProps := filtered.Properties.(ParksProperties)
+
+	square_value := int(parksProps.A1)
+	distance_value := int(math.Round(parksProps.A4))
+	inequality_value := parksProps.H6
+	racism_value := int(math.Round(parksProps.H7))
+
+	// var square_subtitle string = " da média nacional de " // a média nacional deve ser incluída poosteriormente
+	var inequality_subtitle string = "Moradores próximos a praças têm em média 15% mais de renda"
+	var racism_subtitle string = "População negra ou indígena que vive fora da vizinhança das praças"
+
+	result := []ParksDataItem{
+		{"Moradores próximos a praças", nil, strconv.Itoa(square_value) + "%"},
+		{"Distância média até as praças", nil, strconv.Itoa(distance_value) + " metros"},
+		{"Desigualdade de renda", &inequality_subtitle, strconv.FormatFloat(inequality_value, 'f', 2, 64) + "x"},
+		{"Racismo ambiental", &racism_subtitle, strconv.Itoa(racism_value) + "%"},
+	}
+
+	return result, nil
+}

--- a/repositories/cards/square/square_ranking_repository.go
+++ b/repositories/cards/square/square_ranking_repository.go
@@ -1,0 +1,188 @@
+package repositories_cards_square
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	cards_shared "urbverde-api/repositories/cards"
+
+	"github.com/joho/godotenv"
+)
+
+type SquareRankingRepository interface {
+	cards_shared.RepositoryBase
+	LoadRankingData(city string, year string) ([]RankingData, error)
+}
+
+type RankingProperties struct {
+	Ano          int    `json:"ano"`
+	NMMicro      string `json:"nm_micro"`     // Microregion name
+	NRankMicro   int    `json:"n_rank_micro"` // Microregion total
+	A1RankMicro  int    `json:"a1_rank_micro"`
+	A2RankMicro  int    `json:"a2_rank_micro"`
+	A3RankMicro  int    `json:"a3_rank_micro"`
+	A4RankMicro  int    `json:"a4_rank_micro"`
+	NMMeso       string `json:"nm_meso"`     // Mesoregion name
+	NRankMeso    int    `json:"n_rank_meso"` // Mesoregion total
+	A1RankMeso   int    `json:"a1_rank_meso"`
+	A2RankMeso   int    `json:"a2_rank_meso"`
+	A3RankMeso   int    `json:"a3_rank_meso"`
+	A4RankMeso   int    `json:"a4_rank_meso"`
+	NMEstado     string `json:"nm_estado"`     // State name
+	NRankEstado  int    `json:"n_rank_estado"` // State total
+	A1RankEstado int    `json:"a1_rank_estado"`
+	A2RankEstado int    `json:"a2_rank_estado"`
+	A3RankEstado int    `json:"a3_rank_estado"`
+	A4RankEstado int    `json:"a4_rank_estado"`
+}
+
+type RankingDataItem struct {
+	Type   string `json:"type"`
+	Number int    `json:"number"`
+	Of     int    `json:"of"`
+}
+
+type RankingData struct {
+	Title    string            `json:"title"`
+	Subtitle string            `json:"subtitle"`
+	Items    []RankingDataItem `json:"items"`
+}
+
+type externalSquareRankingRepository struct {
+	geoserverURL string
+}
+
+func NewExternalSquareRankingRepository() SquareRankingRepository {
+	_ = godotenv.Load()
+
+	geoserverURL := os.Getenv("GEOSERVER_URL")
+	if geoserverURL == "" {
+		panic("A variável de ambiente GEOSERVER_URL não está definida")
+	}
+
+	geoserverURL = fmt.Sprintf("%sows?service=%s&version=%s&request=%s&typeName=%s&%s",
+		geoserverURL,
+		cards_shared.WfsService,
+		cards_shared.WfsVersion,
+		cards_shared.WfsRequest,
+		cards_shared.TypeName+"dados_pracas_por_municipio",
+		cards_shared.CqlFilterPrefix,
+	)
+
+	return &externalSquareRankingRepository{
+		geoserverURL: geoserverURL,
+	}
+}
+
+func (r *externalSquareRankingRepository) LoadYears(city string) ([]int, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	processProperties := func(props map[string]interface{}) (int, error) {
+		year, ok := props["ano"].(float64)
+		if !ok {
+			return 0, fmt.Errorf("year not found or invalid type")
+		}
+		return int(year), nil
+	}
+
+	return cards_shared.LoadYears(url, processProperties)
+}
+
+func (r *externalSquareRankingRepository) LoadRankingData(city string, year string) ([]RankingData, error) {
+	url := r.geoserverURL + city + "&outputFormat=application/json"
+
+	data, err := cards_shared.FetchFromURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	convYear, err := strconv.Atoi(year)
+	if err != nil {
+		return nil, fmt.Errorf("ano inválido: %w", err)
+	}
+
+	var filtered cards_shared.Feature
+	found := false
+	for _, feature := range data.Features {
+		props, ok := feature.Properties.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("tipo inesperado de propriedades")
+		}
+
+		// Map values
+		var rankingProps RankingProperties
+		rankingProps.Ano = int(props["ano"].(float64))
+
+		// Micro
+		rankingProps.NMMicro = props["nm_micro"].(string)
+		rankingProps.NRankMicro = int(props["n_rank_micro"].(float64))
+		rankingProps.A1RankMicro = int(props["a1_rank_micro"].(float64))
+		rankingProps.A2RankMicro = int(props["a2_rank_micro"].(float64))
+		rankingProps.A3RankMicro = int(props["a3_rank_micro"].(float64))
+		rankingProps.A4RankMicro = int(props["a4_rank_micro"].(float64))
+
+		// Meso
+		rankingProps.NMMeso = props["nm_meso"].(string)
+		rankingProps.NRankMeso = int(props["n_rank_meso"].(float64))
+		rankingProps.A1RankMeso = int(props["a1_rank_meso"].(float64))
+		rankingProps.A2RankMeso = int(props["a2_rank_meso"].(float64))
+		rankingProps.A3RankMeso = int(props["a3_rank_meso"].(float64))
+		rankingProps.A4RankMeso = int(props["a4_rank_meso"].(float64))
+
+		// Estado
+		rankingProps.NMEstado = "São Paulo" // definindo manualmente (temporario)
+		rankingProps.NRankEstado = 645
+		rankingProps.A1RankEstado = int(props["a1_rank_estado"].(float64))
+		rankingProps.A2RankEstado = int(props["a2_rank_estado"].(float64))
+		rankingProps.A3RankEstado = int(props["a3_rank_estado"].(float64))
+		rankingProps.A4RankEstado = int(props["a4_rank_estado"].(float64))
+
+		if rankingProps.Ano == convYear {
+			filtered = feature
+			filtered.Properties = rankingProps
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("ano %d não encontrado nos dados", convYear)
+	}
+
+	rankingProps := filtered.Properties.(RankingProperties)
+
+	result := []RankingData{
+		{
+			Title:    "Municipios do Estado",
+			Subtitle: fmt.Sprintf("Posição do seu município entre os %d do Estado de %s", rankingProps.NRankEstado, rankingProps.NMEstado),
+			Items: []RankingDataItem{
+				{Type: "População atendida pelas praças", Number: rankingProps.A1RankEstado, Of: rankingProps.NRankEstado},
+				{Type: "Área de praças por habitante", Number: rankingProps.A2RankEstado, Of: rankingProps.NRankEstado},
+				{Type: "Área ocupada pela vizinhança das praças", Number: rankingProps.A3RankEstado, Of: rankingProps.NRankEstado},
+				{Type: "Distribuição das praças na cidade", Number: rankingProps.A4RankEstado, Of: rankingProps.NRankEstado},
+			},
+		},
+		{
+			Title:    "Municipios da Mesorregião",
+			Subtitle: fmt.Sprintf("Posição do seu município entre os %d da mesorregião de %s", rankingProps.NRankMeso, rankingProps.NMMeso),
+			Items: []RankingDataItem{
+				{Type: "População atendida pelas praças", Number: rankingProps.A1RankMeso, Of: rankingProps.NRankMeso},
+				{Type: "Área de praças por habitante", Number: rankingProps.A2RankMeso, Of: rankingProps.NRankMeso},
+				{Type: "Área ocupada pela vizinhança das praças", Number: rankingProps.A3RankMeso, Of: rankingProps.NRankMeso},
+				{Type: "Distribuição das praças na cidade", Number: rankingProps.A4RankMeso, Of: rankingProps.NRankMeso},
+			},
+		},
+		{
+			Title:    "Municipios da Microrregião",
+			Subtitle: fmt.Sprintf("Posição do seu município entre os %d da microrregião de %s", rankingProps.NRankMicro, rankingProps.NMMicro),
+			Items: []RankingDataItem{
+				{Type: "População atendida pelas praças", Number: rankingProps.A1RankMicro, Of: rankingProps.NRankMicro},
+				{Type: "Área de praças por habitante", Number: rankingProps.A2RankMicro, Of: rankingProps.NRankMicro},
+				{Type: "Área ocupada pela vizinhança das praças", Number: rankingProps.A3RankMicro, Of: rankingProps.NRankMeso},
+				{Type: "Distribuição das praças na cidade", Number: rankingProps.A4RankMicro, Of: rankingProps.NRankMicro},
+			},
+		},
+	}
+
+	return result, nil
+}

--- a/repositories/cards/vegetal/vegetal_cover_repository.go
+++ b/repositories/cards/vegetal/vegetal_cover_repository.go
@@ -119,14 +119,14 @@ func (r *externalVegetalCoverRepository) LoadCoverData(city string, year string)
 	cover_max_value := int(math.Round(coverProps.B1h4))
 	cover_min_value := int(math.Round(coverProps.B1h3))
 
-	var avg_cover_subtitle string = " da média nacional de "
+	// var avg_cover_subtitle string = " da média nacional de "
 	var futebol_cover_subtitle string = "* Um campo equivale à 6.400 metros quadrados"
 
-	tempLoadCoverData(avg_cover_value, &avg_cover_subtitle)
+	// tempLoadCoverData(avg_cover_value, &avg_cover_subtitle)
 
 	result := []CoverDataItem{
 		{"A área vegetada é igual a", &futebol_cover_subtitle, strconv.Itoa(futebol_cover_value) + " campos de futebol*"},
-		{"Média da cobertura vegetal", &avg_cover_subtitle, strconv.Itoa(avg_cover_value) + "%"},
+		{"Média da cobertura vegetal", nil, strconv.Itoa(avg_cover_value) + "%"},
 		{"A cobertura vegetal na cidade varia entre", nil, strconv.Itoa(cover_min_value) + "% a " + strconv.Itoa(cover_max_value) + "%"},
 	}
 

--- a/repositories/cards/vegetal/vegetal_inequality_repository.go
+++ b/repositories/cards/vegetal/vegetal_inequality_repository.go
@@ -115,14 +115,14 @@ func (r *externalVegetalInequalityRepository) LoadInequalityData(city string, ye
 	// vegetation_vigor_value := int(math.Round(inequalityProps.B1h4))
 
 	var residents_inequality_subtitle = "Porcentagem vivendo nas regiões menos vegetadas"
-	var environmental_inequality_subtitle string = " da média nacional de "
+	// var environmental_inequality_subtitle string = " da média nacional de "
 	// var vegetation_vigor_subtitle string = "Indica a média da saúde da vegetação"
 
-	tempLoadInequalityData(environmental_inequality_value, &environmental_inequality_subtitle)
+	// tempLoadInequalityData(environmental_inequality_value, &environmental_inequality_subtitle)
 
 	result := []InequalityDataItem{
 		{"Moradores em áreas de pouca vegetação", &residents_inequality_subtitle, strconv.Itoa(residents_inequality_value) + "%"},
-		{"Desigualdade ambiental e social (IDSA)", &environmental_inequality_subtitle, strconv.Itoa(environmental_inequality_value)},
+		{"Desigualdade ambiental e social (IDSA)", nil, strconv.Itoa(environmental_inequality_value)},
 		// {"Vigor da vegetação (NDVI)", &vegetation_vigor_subtitle, "*Dado em construção*"},
 	}
 

--- a/repositories/cards/weather/weather_heat_repository.go
+++ b/repositories/cards/weather/weather_heat_repository.go
@@ -27,7 +27,7 @@ type HeatProperties struct {
 // Response JSON structure
 type HeatDataItem struct {
 	Title    string  `json:"title"`
-	Subtitle *string `json:"subtitle,omitempty"` // Omitir caso seja nil
+	Subtitle *string `json:"subtitle,omitempty"`
 	Value    string  `json:"value"`
 }
 
@@ -113,7 +113,6 @@ func (r *externalWeatherHeatRepository) LoadHeatData(city string, year string) (
 
 	heatProps := filtered.Properties.(HeatProperties)
 
-	// Values
 	black_indigenous_percentage := int(math.Round(heatProps.H12b * 100))
 	women_percentage := int(math.Round(heatProps.H11b * 100))
 	children_percentage := int(math.Round(heatProps.H10b * 100))

--- a/repositories/cards/weather/weather_info_repository.go
+++ b/repositories/cards/weather/weather_info_repository.go
@@ -110,7 +110,6 @@ func (r *externalWeatherInfoRepository) LoadInfoData(city string) ([]InfoDataIte
 
 	data = sortGeneralData(data)
 
-	// busca o valor mais recente != 0
 	findLatestNonZero := func(features []cards_shared.Feature, key string) (float64, bool) {
 		for _, feature := range features {
 			props, ok := feature.Properties.(map[string]interface{})

--- a/repositories/cards/weather/weather_temperature_repository.go
+++ b/repositories/cards/weather/weather_temperature_repository.go
@@ -27,7 +27,7 @@ type TemperatureProperties struct {
 // Response JSON structure
 type TemperatureDataItem struct {
 	Title    string  `json:"title"`
-	Subtitle *string `json:"subtitle,omitempty"` // Omitir caso seja nil
+	Subtitle *string `json:"subtitle,omitempty"`
 	Value    string  `json:"value"`
 }
 
@@ -116,27 +116,20 @@ func (r *externalWeatherTemperatureRepository) LoadTemperatureData(city string, 
 
 	temperatureProps := filtered.Properties.(TemperatureProperties)
 
-	// Values
 	heat_island_value := int(math.Round(temperatureProps.C1))
 	avg_temp_value := int(math.Round(temperatureProps.C2))
 	amplitude_value := temperatureProps.H5b
 	max_temp_value := int(math.Round(temperatureProps.C3))
 
-	// Result
-	// Nível de ilha de calor
-	// Temperatura média da superfície
-	// Maior amplitude
-	// Temperatura máxima da superfície
-
-	var heat_island_subtitle string = " da média nacional de "
-	var avg_temp_subtitle string = " da média nacional de "
+	// var heat_island_subtitle string = " da média nacional de " // deve ser adicionado junto do dado nacional
+	// var avg_temp_subtitle string = " da média nacional de "
 	var amplitude_subtitle string = "É a diferença entre a temperatura mais quente e a mais fria"
 
-	tempLoadData(heat_island_value, avg_temp_value, &heat_island_subtitle, &avg_temp_subtitle)
+	// tempLoadData(heat_island_value, avg_temp_value, &heat_island_subtitle, &avg_temp_subtitle)
 
 	result := []TemperatureDataItem{
-		{"Nível de ilha de calor", &heat_island_subtitle, strconv.Itoa(heat_island_value)},
-		{"Temperatura média da superfície", &avg_temp_subtitle, strconv.Itoa(avg_temp_value) + "°C"},
+		{"Nível de ilha de calor", nil, strconv.Itoa(heat_island_value)},
+		{"Temperatura média da superfície", nil, strconv.Itoa(avg_temp_value) + "°C"},
 		{"Maior amplitude", &amplitude_subtitle, strconv.Itoa(amplitude_value) + "°C"},
 		{"Temperatura máxima da superfície", nil, strconv.Itoa(max_temp_value) + "°C"},
 	}

--- a/repositories/cards/weather/weather_temperature_repository_test.go
+++ b/repositories/cards/weather/weather_temperature_repository_test.go
@@ -44,8 +44,8 @@ func TestLoadTemperatureData(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected := []TemperatureDataItem{
-			{"Nível de ilha de calor", utils.StringPtr("Acima da média nacional de 0"), "2"},
-			{"Temperatura média da superfície", utils.StringPtr("Acima da média nacional de 0"), "32°C"},
+			{"Nível de ilha de calor", nil, "2"},
+			{"Temperatura média da superfície", nil, "32°C"},
 			{"Maior amplitude", utils.StringPtr("É a diferença entre a temperatura mais quente e a mais fria"), "9°C"},
 			{"Temperatura máxima da superfície", nil, "42°C"},
 		}

--- a/routes/cards/cards_routes.go
+++ b/routes/cards/cards_routes.go
@@ -209,6 +209,15 @@ func setupVegetalInfoRoutes(rg *gin.RouterGroup) {
 	rg.GET("/cards/vegetal/info", infoController.LoadInfoData)
 }
 
+// @Summary Retorna dados dos parques e praças
+// @Description Retorna dados de parques e praças para a camada
+// @Tags cards/square
+// @Accept json
+// @Produce json
+// @Param city query string true "Código de município"
+// @Success 200 {object} []CardsDataItem
+// @Failure 400 {object} ErrorResponse
+// @Router /cards/square/parks [get]
 func setupSquareParksRoutes(rg *gin.RouterGroup) {
 	parksRepo := repositories_cards_square.NewExternalSquareParksRepository()
 	parksService := services_cards_square.NewSquareParksService(parksRepo)
@@ -217,6 +226,15 @@ func setupSquareParksRoutes(rg *gin.RouterGroup) {
 	rg.GET("/cards/square/parks", parksController.LoadParksData)
 }
 
+// @Summary Retorna dados sobre desigualdade
+// @Description Retorna dados de desigualdade para a camada
+// @Tags cards/square
+// @Accept json
+// @Produce json
+// @Param city query string true "Código de município"
+// @Success 200 {object} []CardsDataItem
+// @Failure 400 {object} ErrorResponse
+// @Router /cards/square/inequality [get]
 func setupSquareInequalityRoutes(rg *gin.RouterGroup) {
 	inequalityRepo := repositories_cards_square.NewExternalSquareInequalityRepository()
 	inequalityService := services_cards_square.NewSquareInequalityService(inequalityRepo)
@@ -225,6 +243,16 @@ func setupSquareInequalityRoutes(rg *gin.RouterGroup) {
 	rg.GET("/cards/square/inequality", inequalityController.LoadInequalityData)
 }
 
+// @Summary Retorna dados de ranking
+// @Description Retorna dados para a construção do ranking de praças e parques
+// @Tags cards/square
+// @Accept json
+// @Produce json
+// @Param city query string true "Código de município"
+// @Param year query string false "Ano dos dados"
+// @Success 200 {object} []RankingData
+// @Failure 400 {object} ErrorResponse
+// @Router /cards/square/ranking [get]
 func setupSquareRankingRoutes(rg *gin.RouterGroup) {
 	rankRepo := repositories_cards_square.NewExternalSquareRankingRepository()
 	rankService := services_cards_square.NewSquareRankingService(rankRepo)
@@ -233,6 +261,15 @@ func setupSquareRankingRoutes(rg *gin.RouterGroup) {
 	rg.GET("/cards/square/ranking", rankController.LoadRankingData)
 }
 
+// @Summary Retorna dados adicionais para a camada de praças e parques
+// @Description Retorna dados adicionais para a camada
+// @Tags cards/square
+// @Accept json
+// @Produce json
+// @Param city query string true "Código de município"
+// @Success 200 {object} []CardsDataItem
+// @Failure 400 {object} ErrorResponse
+// @Router /cards/square/info [get]
 func setupSquareInfoRoutes(rg *gin.RouterGroup) {
 	squareRepo := repositories_cards_vegetal.NewExternalVegetalInfoRepository()
 	squareService := services_cards_vegetal.NewVegetalInfoService(squareRepo)

--- a/routes/cards/cards_routes.go
+++ b/routes/cards/cards_routes.go
@@ -10,6 +10,10 @@ import (
 	repositories_cards_vegetal "urbverde-api/repositories/cards/vegetal"
 	services_cards_vegetal "urbverde-api/services/cards/vegetal"
 
+	controllers_cards_square "urbverde-api/controllers/cards/square"
+	repositories_cards_square "urbverde-api/repositories/cards/square"
+	services_cards_square "urbverde-api/services/cards/square"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -39,20 +43,28 @@ type ErrorResponse struct {
 func SetupCardsRoutes(rg *gin.RouterGroup) {
 	SetupWeatherRoutes(rg)
 	SetupVegetalRoutes(rg)
+	SetupSquareRoutes(rg)
 }
 
 func SetupWeatherRoutes(rg *gin.RouterGroup) {
 	setupTemperatureRoutes(rg)
 	setupHeatRoutes(rg)
-	setupRankingWeatherRoutes(rg)
+	setupWeatherRankingRoutes(rg)
 	setupWeatherInfoRoutes(rg)
 }
 
 func SetupVegetalRoutes(rg *gin.RouterGroup) {
 	setupCoverRoutes(rg)
-	setupInequalityRoutes(rg)
-	setupRankingVegetalRoutes(rg)
+	setupVegetalInequalityRoutes(rg)
+	setupVegetalRankingRoutes(rg)
 	setupVegetalInfoRoutes(rg)
+}
+
+func SetupSquareRoutes(rg *gin.RouterGroup) {
+	setupSquareParksRoutes(rg)
+	setupSquareInequalityRoutes(rg)
+	setupSquareRankingRoutes(rg)
+	setupSquareInfoRoutes(rg)
 }
 
 // @Summary Retorna dados de temperatura
@@ -101,7 +113,7 @@ func setupHeatRoutes(rg *gin.RouterGroup) {
 // @Success 200 {object} []RankingData
 // @Failure 400 {object} ErrorResponse
 // @Router /cards/weather/ranking [get]
-func setupRankingWeatherRoutes(rg *gin.RouterGroup) {
+func setupWeatherRankingRoutes(rg *gin.RouterGroup) {
 	rankRepo := repositories_cards_weather.NewExternalWeatherRankingRepository()
 	rankService := services_cards_weather.NewWeatherRankingService(rankRepo)
 	rankController := controllers_cards_weather.NewWeatherRankingController(rankService)
@@ -154,7 +166,7 @@ func setupCoverRoutes(rg *gin.RouterGroup) {
 // @Success 200 {object} []CardsDataItem
 // @Failure 400 {object} ErrorResponse
 // @Router /cards/vegetal/inequality [get]
-func setupInequalityRoutes(rg *gin.RouterGroup) {
+func setupVegetalInequalityRoutes(rg *gin.RouterGroup) {
 	inequalityRepo := repositories_cards_vegetal.NewExternalVegetalInequalityRepository()
 	inequalityService := services_cards_vegetal.NewVegetalInequalityService(inequalityRepo)
 	inequalityController := controllers_cards_vegetal.NewVegetalInequalityController(inequalityService)
@@ -172,7 +184,7 @@ func setupInequalityRoutes(rg *gin.RouterGroup) {
 // @Success 200 {object} []RankingData
 // @Failure 400 {object} ErrorResponse
 // @Router /cards/vegetal/ranking [get]
-func setupRankingVegetalRoutes(rg *gin.RouterGroup) {
+func setupVegetalRankingRoutes(rg *gin.RouterGroup) {
 	rankRepo := repositories_cards_vegetal.NewExternalVegetalRankingRepository()
 	rankService := services_cards_vegetal.NewVegetalRankingService(rankRepo)
 	rankController := controllers_cards_vegetal.NewVegetalRankingController(rankService)
@@ -195,4 +207,36 @@ func setupVegetalInfoRoutes(rg *gin.RouterGroup) {
 	infoController := controllers_cards_vegetal.NewVegetalInfoController(infoService)
 
 	rg.GET("/cards/vegetal/info", infoController.LoadInfoData)
+}
+
+func setupSquareParksRoutes(rg *gin.RouterGroup) {
+	parksRepo := repositories_cards_square.NewExternalSquareParksRepository()
+	parksService := services_cards_square.NewSquareParksService(parksRepo)
+	parksController := controllers_cards_square.NewSquareParksController(parksService)
+
+	rg.GET("/cards/square/parks", parksController.LoadParksData)
+}
+
+func setupSquareInequalityRoutes(rg *gin.RouterGroup) {
+	inequalityRepo := repositories_cards_square.NewExternalSquareInequalityRepository()
+	inequalityService := services_cards_square.NewSquareInequalityService(inequalityRepo)
+	inequalityController := controllers_cards_square.NewSquareInequalityController(inequalityService)
+
+	rg.GET("/cards/square/inequality", inequalityController.LoadInequalityData)
+}
+
+func setupSquareRankingRoutes(rg *gin.RouterGroup) {
+	rankRepo := repositories_cards_square.NewExternalSquareRankingRepository()
+	rankService := services_cards_square.NewSquareRankingService(rankRepo)
+	rankController := controllers_cards_square.NewSquareRankingController(rankService)
+
+	rg.GET("/cards/square/ranking", rankController.LoadRankingData)
+}
+
+func setupSquareInfoRoutes(rg *gin.RouterGroup) {
+	squareRepo := repositories_cards_vegetal.NewExternalVegetalInfoRepository()
+	squareService := services_cards_vegetal.NewVegetalInfoService(squareRepo)
+	squareController := controllers_cards_vegetal.NewVegetalInfoController(squareService)
+
+	rg.GET("/cards/square/info", squareController.LoadInfoData)
 }

--- a/services/cards/square/square_inequality_service.go
+++ b/services/cards/square/square_inequality_service.go
@@ -1,0 +1,39 @@
+package services_cards_square
+
+import (
+	cards_shared "urbverde-api/repositories/cards"
+	repositories_cards_square "urbverde-api/repositories/cards/square"
+)
+
+type SquareInequalityService interface {
+	cards_shared.RepositoryBase
+	LoadInequalityData(city string, year string) ([]repositories_cards_square.SquareInequalityDataItem, error)
+}
+
+type squareInequalityService struct {
+	SquareInequalityRepository repositories_cards_square.SquareInequalityRepository
+}
+
+func NewSquareInequalityService(ar repositories_cards_square.SquareInequalityRepository) SquareInequalityService {
+	return &squareInequalityService{
+		SquareInequalityRepository: ar,
+	}
+}
+
+func (as *squareInequalityService) LoadYears(city string) ([]int, error) {
+	data, err := as.SquareInequalityRepository.LoadYears(city)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (as *squareInequalityService) LoadInequalityData(city string, year string) ([]repositories_cards_square.SquareInequalityDataItem, error) {
+	data, err := as.SquareInequalityRepository.LoadInequalityData(city, year)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/services/cards/square/square_info_service.go
+++ b/services/cards/square/square_info_service.go
@@ -1,0 +1,28 @@
+package services_cards_square
+
+import (
+	repositories_cards_square "urbverde-api/repositories/cards/square"
+)
+
+type SquareInfoService interface {
+	LoadInfoData(city string) ([]repositories_cards_square.InfoDataItem, error)
+}
+
+type squareInfoService struct {
+	SquareInfoRepository repositories_cards_square.SquareInfoRepository
+}
+
+func NewSquareInfoService(ar repositories_cards_square.SquareInfoRepository) SquareInfoService {
+	return &squareInfoService{
+		SquareInfoRepository: ar,
+	}
+}
+
+func (as *squareInfoService) LoadInfoData(city string) ([]repositories_cards_square.InfoDataItem, error) {
+	data, err := as.SquareInfoRepository.LoadInfoData(city)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/services/cards/square/square_parks_service.go
+++ b/services/cards/square/square_parks_service.go
@@ -1,0 +1,39 @@
+package services_cards_square
+
+import (
+	cards_shared "urbverde-api/repositories/cards"
+	repositories_cards_square "urbverde-api/repositories/cards/square"
+)
+
+type SquareParksService interface {
+	cards_shared.RepositoryBase
+	LoadParksData(city string, year string) ([]repositories_cards_square.ParksDataItem, error)
+}
+
+type squareParksService struct {
+	SquareParksRepository repositories_cards_square.SquareParksRepository
+}
+
+func NewSquareParksService(ar repositories_cards_square.SquareParksRepository) SquareParksService {
+	return &squareParksService{
+		SquareParksRepository: ar,
+	}
+}
+
+func (as *squareParksService) LoadYears(city string) ([]int, error) {
+	data, err := as.SquareParksRepository.LoadYears(city)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (as *squareParksService) LoadParksData(city string, year string) ([]repositories_cards_square.ParksDataItem, error) {
+	data, err := as.SquareParksRepository.LoadParksData(city, year)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/services/cards/square/square_ranking_service.go
+++ b/services/cards/square/square_ranking_service.go
@@ -1,0 +1,39 @@
+package services_cards_square
+
+import (
+	cards_shared "urbverde-api/repositories/cards"
+	repositories_cards_square "urbverde-api/repositories/cards/square"
+)
+
+type SquareRankingService interface {
+	cards_shared.RepositoryBase
+	LoadRankingData(city string, year string) ([]repositories_cards_square.RankingData, error)
+}
+
+type squareRankingService struct {
+	SquareRankingRepository repositories_cards_square.SquareRankingRepository
+}
+
+func NewSquareRankingService(ar repositories_cards_square.SquareRankingRepository) SquareRankingService {
+	return &squareRankingService{
+		SquareRankingRepository: ar,
+	}
+}
+
+func (as *squareRankingService) LoadYears(city string) ([]int, error) {
+	data, err := as.SquareRankingRepository.LoadYears(city)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (as *squareRankingService) LoadRankingData(city string, year string) ([]repositories_cards_square.RankingData, error) {
+	data, err := as.SquareRankingRepository.LoadRankingData(city, year)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
# Carregamento dos dados dos cards da camada de Praças e Parques

Este pull request implementa o carregamento dos dados para os cards da camada de Praças e Parques, adicionando as seguintes novas rotas:

## Rotas Adicionadas
**v1/cards/square**

*   **GET v1/cards/square/parks**

    Recupera dados de parques e praças para os cards.

    **Parâmetros:**

    *   `city` (obrigatório): A cidade para a qual recuperar os dados.
    *   `year` (opcional): O ano para o qual recuperar os dados. Se não for fornecido, retorna uma lista de anos disponíveis para consulta.

*   **GET v1/cards/square/inequality**

    Recupera dados de desigualdade para os cards de praças e parques.

    **Parâmetros:**

    *   `city` (obrigatório): A cidade para a qual recuperar os dados.
    *   `year` (opcional): O ano para o qual recuperar os dados. Se não for fornecido, retorna uma lista de anos disponíveis para consulta.

*   **GET v1/cards/square/ranking**

    Recupera dados de ranking para os cards de praças e parques.

    **Parâmetros:**

    *   `city` (obrigatório): A cidade para a qual recuperar os dados.
    *   `year` (opcional): O ano para o qual recuperar os dados. Se não for fornecido, retorna uma lista de anos disponíveis para consulta.

*   **GET v1/cards/square/info**

    Recupera informações gerais para os cards de praças e parques.

    **Parâmetros:**

    *   `city` (obrigatório): A cidade para a qual recuperar os dados.

## Mudanças Realizadas

*   Implementação das novas rotas conforme descrito acima.
*   Adição da lógica necessária para buscar os dados.
